### PR TITLE
Add support for reading the "Requires at least" header from the plugin or theme file.

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -1,16 +1,19 @@
 parameters:
 	WPCompat:
+		pluginFile: null
 		requiresAtLeast: null
 
 services:
 	-
 		class: WPCompat\PHPStan\Rules\SinceVersionRule
 		arguments:
+			pluginFile: %WPCompat.pluginFile%
 			requiresAtLeast: %WPCompat.requiresAtLeast%
 		tags:
 			- phpstan.rules.rule
 
 parametersSchema:
 	WPCompat: structure([
-		requiresAtLeast: string(),
+		pluginFile: schema(string(), nullable()),
+		requiresAtLeast: schema(string(), nullable()),
 	])

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 WPCompat is a PHPStan extension which helps verify that your PHP code is compatible with a given version of WordPress. You can use it to help ensure that your plugin or theme remains compatible with its "Requires at least" version.
 
-It works by checking that the declared `@since` version of any WordPress functions or class methods that are in use is lower than or equal to the minimum version of WordPress that your code supports. For example, if your plugin supports WordPress 6.0 or higher but the `get_template_hierarchy()` function is used unconditionally, the extension will trigger an error because that function was only introduced in WordPress 6.1.
+It works by checking that the declared `@since` version of any WordPress functions or class methods that are in use is lower than or equal to the minimum version of WordPress that your code supports. For example, if your plugin or theme supports WordPress 6.0 or higher but the `get_template_hierarchy()` function is used unconditionally, the extension will trigger an error because that function was only introduced in WordPress 6.1.
 
 If your code is correctly guarded with a valid `function_exists()` check then an error won't be triggered. The extension doesn't yet support the same for `method_exists()` when calling methods, but it's on the todo list.
 
@@ -36,7 +36,25 @@ includes:
 
 ## Configuration
 
-Add the minimum supported WordPress version number to the parameters in your PHPStan config file. Note that this must be a string so it must be wrapped in quote marks.
+### Themes
+
+If your style.css file contains a "Requires at least" header then wp-compat will read this header and use its value as the minimum supported WordPress version. There is no need for any additional config.
+
+### Plugins
+
+If the name of your main plugin file matches its parent directory -- for example `my-plugin/my-plugin.php` -- then wp-compat will read the "Requires at least" header from this file and use its value as the minimum supported WordPress version. There is no need for any additional config.
+
+If your main plugin file is named otherwise or located elsewhere, you can specify its name in your PHPStan config file:
+
+```neon
+parameters:
+    WPCompat:
+        pluginFile: my-plugin.php
+```
+
+### Manual config
+
+Alternatively you can specify the minimum supported WordPress version number of your plugin or theme directly in your PHPStan config file. Note that this must be a string so it must be wrapped in quote marks.
 
 ```neon
 parameters:

--- a/tests/Rules/CompatTest.php
+++ b/tests/Rules/CompatTest.php
@@ -13,6 +13,7 @@ class CompatTest extends \PHPStan\Testing\RuleTestCase {
 	protected function getRule(): \PHPStan\Rules\Rule {
 		return new SinceVersionRule(
 			'1.0',
+			null,
 			self::createReflectionProvider(),
 		);
 	}

--- a/tests/Rules/SinceVersionRuleTest.php
+++ b/tests/Rules/SinceVersionRuleTest.php
@@ -13,6 +13,7 @@ class SinceVersionTest extends \PHPStan\Testing\RuleTestCase {
 	protected function getRule(): \PHPStan\Rules\Rule {
 		return new SinceVersionRule(
 			'6.0',
+			null,
 			self::createReflectionProvider(),
 		);
 	}

--- a/tests/Unit/HeaderTest.php
+++ b/tests/Unit/HeaderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPCompat\PHPStan\Tests;
+
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Testing\PHPStanTestCase;
+use WPCompat\PHPStan\Rules\SinceVersionRule;
+
+class HeaderTest extends PHPStanTestCase {
+	private static ReflectionProvider $reflectionProvider;
+
+	public static function setUpBeforeClass(): void {
+		self::$reflectionProvider = self::createReflectionProvider();
+	}
+
+	/**
+	 * @dataProvider dataMinimumVersions
+	 */
+	public function testMinimumVersionIsCorrect( ?string $requiresAtLeast, ?string $pluginFile, string $expected ): void {
+		$since = new SinceVersionRule(
+			$requiresAtLeast,
+			$pluginFile,
+			self::$reflectionProvider,
+		);
+
+		self::assertSame( $expected, $since->getMinVersion() );
+	}
+
+	/**
+	 * @phpstan-return list<array{
+	 *   ?string,
+	 *   ?string,
+	 *   string,
+	 * }>
+	 */
+	public function dataMinimumVersions(): array {
+		return [
+			[
+				'1.2',
+				null,
+				'1.2.0',
+			],
+			[
+				'1.2.3',
+				null,
+				'1.2.3',
+			],
+			[
+				null,
+				'tests/Unit/data/plugin1.php',
+				'5.0.0',
+			],
+		];
+	}
+}

--- a/tests/Unit/data/plugin1.php
+++ b/tests/Unit/data/plugin1.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Plugin Name: My Plugin
+ * Description: This is my plugin
+ * Version: 1.2.3
+ * Author: John Blackbourn
+ * Requires at least: 5.0
+ * Requires PHP: 7.4
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * License: GPL v2 or later
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}


### PR DESCRIPTION
This adds support for automatically reading the "Requires at least" header from the main plugin file or the theme's style.css file. If the name of your plugin file doesn't match the name of its parent directory -- eg `my-plugin/my-plugin.php` -- then you can pass the file name in the `pluginFile` config:

```neon
parameters:
    WPCompat:
        pluginFile: my-plugin.php
```

This makes the `requiresAtLeast` config option mostly redundant, although it's retained in case it's needed.