### PR TITLE
Add support for `method_exists()` guards

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -10,6 +10,11 @@ services:
 		tags:
 			- phpstan.rules.rule
 
+	-
+		class: WPCompat\PHPStan\Rules\MethodExistsVisitor
+		tags:
+			- phpstan.parser.richParserNodeVisitor
+
 parametersSchema:
 	WPCompat: structure([
 		requiresAtLeast: string(),

--- a/src/Rules/MethodExistsVisitor.php
+++ b/src/Rules/MethodExistsVisitor.php
@@ -35,11 +35,12 @@ final class MethodExistsVisitor extends NodeVisitorAbstract {
 					count( $args ) >= 2
 					&& $args[1]->value instanceof Node\Scalar\String_
 				) {
-					$this->inMethodExists[ count( $this->ifStack ) ] = [ $args[0]->value, $args[1]->value ];
+					$this->inMethodExists[ count( $this->ifStack ) ] ?? [];
+					$this->inMethodExists[ count( $this->ifStack ) ][] = [ $args[0]->value, $args[1]->value ];
 				}
 			}
-		} elseif ( $node instanceof Node\Expr\CallLike ) {
-			$node->setAttribute( self::ATTRIBUTE_NAME, $this->inMethodExists );
+		} elseif ( $node instanceof Node\Expr\CallLike && count( $this->inMethodExists ) > 0 ) {
+			$node->setAttribute( self::ATTRIBUTE_NAME, $this->inMethodExists[ count( $this->ifStack ) ] );
 		}
 
 		return null;

--- a/src/Rules/MethodExistsVisitor.php
+++ b/src/Rules/MethodExistsVisitor.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace WPCompat\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use PHPStan\Node\Printer\ExprPrinter;
+use function count;
+
+final class MethodExistsVisitor extends NodeVisitorAbstract {
+
+
+	public const ATTRIBUTE_NAME = 'in_method_exists';
+
+	/**
+	 * @var array<int, list<array{Node\Expr, Node\Scalar\String_}>>
+	 */
+	private array $inMethodExists = [];
+
+	/**
+	 * @var list<Node\Stmt\If_>
+	 */
+	private array $ifStack = [];
+
+	public function enterNode( Node $node ): ?Node {
+		if ( $node instanceof Node\Stmt\If_ ) {
+			$this->ifStack[] = $node;
+		}
+
+		if ( $node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name && ! $node->isFirstClassCallable() ) {
+			$functionName = $node->name->toLowerString();
+			if ( $functionName === 'method_exists' ) {
+				$args = $node->getArgs();
+				if (
+					count( $args ) >= 2
+					&& $args[1]->value instanceof Node\Scalar\String_
+				) {
+					$this->inMethodExists[ count( $this->ifStack ) ] = [ $args[0]->value, $args[1]->value ];
+				}
+			}
+		} elseif ( $node instanceof Node\Expr\CallLike ) {
+			$node->setAttribute( self::ATTRIBUTE_NAME, $this->inMethodExists );
+		}
+
+		return null;
+	}
+
+	public function leaveNode( Node $node ) {
+		if ( $node instanceof Node\Stmt\If_ ) {
+			unset( $this->inMethodExists[ count( $this->ifStack ) ] );
+			array_pop( $this->ifStack );
+		}
+
+		return null;
+	}
+}

--- a/src/Rules/MethodExistsVisitor.php
+++ b/src/Rules/MethodExistsVisitor.php
@@ -35,7 +35,9 @@ final class MethodExistsVisitor extends NodeVisitorAbstract {
 					count( $args ) >= 2
 					&& $args[1]->value instanceof Node\Scalar\String_
 				) {
-					$this->inMethodExists[ count( $this->ifStack ) ] ?? [];
+					if ( ! array_key_exists( count( $this->ifStack ), $this->inMethodExists ) ) {
+						$this->inMethodExists[ count( $this->ifStack ) ] = [];
+					}
 					$this->inMethodExists[ count( $this->ifStack ) ][] = [ $args[0]->value, $args[1]->value ];
 				}
 			}

--- a/src/Rules/SinceVersionRule.php
+++ b/src/Rules/SinceVersionRule.php
@@ -107,7 +107,7 @@ final class SinceVersionRule implements Rule {
 
 		$methodName = self::getMethodName( $node );
 
-		$inMethodExists = $node->getAttribute( MethodExistsVisitor::ATTRIBUTE_NAME );
+		$inMethodExists = $node->getAttribute( MethodExistsVisitor::ATTRIBUTE_NAME, [] );
 		foreach ( $inMethodExists as [$objectOrClass, $method] ) {
 			if ( $methodName !== $method->value ) {
 				continue;

--- a/tests/tests.neon
+++ b/tests/tests.neon
@@ -1,3 +1,9 @@
 parameters:
 	bootstrapFiles:
 		- ../vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
+
+services:
+	-
+		class: WPCompat\PHPStan\Rules\MethodExistsVisitor
+		tags:
+			- phpstan.parser.richParserNodeVisitor


### PR DESCRIPTION
implementation for https://github.com/johnbillion/wp-compat/pull/6

---

in case you find more variants which needs fixing and are not covered yet, please send another failing test-case and I will provide a followup