### PR TITLE
Correctly handle encapsed string method names.

### DIFF
--- a/src/Rules/SinceVersionRule.php
+++ b/src/Rules/SinceVersionRule.php
@@ -312,21 +312,7 @@ final class SinceVersionRule implements Rule {
 			return $node->name->toString();
 		}
 
-		if ( $node->name instanceof Variable ) {
-			return null;
-		}
-
-		if ( $node->name instanceof Concat ) {
-			return null;
-		}
-
-		throw new \RuntimeException(
-			self::error(
-				'Failed to get method name from %s in %s:%d. Please report this to https://github.com/johnbillion/wp-compat/issues.',
-				$node,
-				$scope,
-			)
-		);
+		return null;
 	}
 
 	/**

--- a/tests/Rules/data/SinceVersion.php
+++ b/tests/Rules/data/SinceVersion.php
@@ -118,6 +118,11 @@ $concat = $_GET['foo'];
 TestClass::{'template_args_' . $concat}();
 $test_instance->{'template_args_' . $concat}();
 
+// Encapsed string method name:
+$foo = $_GET['foo'];
+TestClass::{"template_args_$foo"}();
+$test_instance->{"template_args_$foo"}();
+
 // Closure:
 $my_closure = function() {};
 $my_closure();


### PR DESCRIPTION
similar to https://github.com/johnbillion/wp-compat/commit/5ef45a68b3fe61c33bfd599cfc62e88bc48543c5