### PR TITLE
Update WPCS dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"phpstan/phpstan-phpunit": "^1.0 || ^2.0",
 		"phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
 		"phpunit/phpunit": "^8.5 || ^9.0",
-		"wp-coding-standards/wpcs": "^3.4"
+		"wp-coding-standards/wpcs": "3.4.1"
 	},
 	"license": "MIT",
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"phpstan/phpstan-phpunit": "^1.0 || ^2.0",
 		"phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
 		"phpunit/phpunit": "^8.5 || ^9.0",
-		"wp-coding-standards/wpcs": "3.1.0"
+		"wp-coding-standards/wpcs": "^3.4"
 	},
 	"license": "MIT",
 	"autoload": {


### PR DESCRIPTION
```
Root composer.json requires wp-coding-standards/wpcs 3.1.0 (exact version match: 3.1.0 or 3.1.0.0), found wp-coding-standards/wpcs[3.1.0] but these were not loaded, because they are affected by security advisories ("PKSA-mh9b-91zm-m1gy"). Go to https://packagist.org/security-advisories/ to find advisory details.
```