### PR TITLE
Fix the test harness on PHP 7.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,5 @@ Bug reports, code contributions, and general feedback are very welcome. These sh
 ```
 composer generate vendor/wordpress/wordpress
 ```
+
+Note that the version of WordPress that gets installed depends on the version of PHP in use, so generate the symbols using the most recent version of PHP.

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,20 @@
 		"phpstan",
 		"wordpress"
 	],
+	"repositories": [
+		{
+			"comment": "Provided in place of a package such as roots/wordpress so its PHP version requirement doesn't prevent installation on older versions of PHP. WordPress core is used here only as a source of symbols for the tests, it's never executed.",
+			"type": "package",
+			"package": {
+				"name": "wordpress/wordpress",
+				"version": "7.1",
+				"dist": {
+					"type": "zip",
+					"url": "https://downloads.wordpress.org/release/wordpress-7.1-no-content.zip"
+				}
+			}
+		}
+	],
 	"require": {
 		"php": ">= 7.2.24",
 		"phpstan/phpstan": "^1.12 || ^2.0",
@@ -20,11 +34,11 @@
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
 		"nikic/php-parser": "^4.18 || ^5.1",
-		"roots/wordpress": "*",
 		"phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
 		"phpstan/phpstan-phpunit": "^1.0 || ^2.0",
 		"phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
 		"phpunit/phpunit": "^8.5 || ^9.0",
+		"wordpress/wordpress": "7.1",
 		"wp-coding-standards/wpcs": "3.4.1"
 	},
 	"license": "MIT",
@@ -46,16 +60,14 @@
 			"includes": [
 				"extension.neon"
 			]
-		},
-		"wordpress-install-dir": "vendor/wordpress/wordpress"
+		}
 	},
 	"config": {
 		"sort-packages": true,
 		"preferred-install": "dist",
 		"allow-plugins": {
 			"composer/installers": true,
-			"dealerdirect/phpcodesniffer-composer-installer": true,
-			"roots/wordpress-core-installer": true
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	},
 	"scripts": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
 		"nikic/php-parser": "^4.18 || ^5.1",
-		"roots/wordpress": "^7.1",
+		"roots/wordpress": "*",
 		"phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
 		"phpstan/phpstan-phpunit": "^1.0 || ^2.0",
 		"phpstan/phpstan-strict-rules": "^1.0 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -12,20 +12,6 @@
 		"phpstan",
 		"wordpress"
 	],
-	"repositories": [
-		{
-			"comment": "Provided in place of a package such as roots/wordpress so its PHP version requirement doesn't prevent installation on older versions of PHP. WordPress core is used here only as a source of symbols for the tests, it's never executed.",
-			"type": "package",
-			"package": {
-				"name": "wordpress/wordpress",
-				"version": "7.1",
-				"dist": {
-					"type": "zip",
-					"url": "https://downloads.wordpress.org/release/wordpress-7.1-no-content.zip"
-				}
-			}
-		}
-	],
 	"require": {
 		"php": ">= 7.2.24",
 		"phpstan/phpstan": "^1.12 || ^2.0",
@@ -38,7 +24,7 @@
 		"phpstan/phpstan-phpunit": "^1.0 || ^2.0",
 		"phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
 		"phpunit/phpunit": "^8.5 || ^9.0",
-		"wordpress/wordpress": "7.1",
+		"roots/wordpress": "*",
 		"wp-coding-standards/wpcs": "3.4.1"
 	},
 	"license": "MIT",
@@ -52,7 +38,8 @@
 			"tests/"
 		],
 		"exclude-from-classmap": [
-			"tests/Unit/data/symbols/"
+			"tests/Unit/data/symbols/",
+			"tests/stubs/"
 		]
 	},
 	"extra": {
@@ -60,14 +47,16 @@
 			"includes": [
 				"extension.neon"
 			]
-		}
+		},
+		"wordpress-install-dir": "vendor/wordpress/wordpress"
 	},
 	"config": {
 		"sort-packages": true,
 		"preferred-install": "dist",
 		"allow-plugins": {
 			"composer/installers": true,
-			"dealerdirect/phpcodesniffer-composer-installer": true
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"roots/wordpress-core-installer": true
 		}
 	},
 	"scripts": {

--- a/tests/stubs/wordpress-stubs.php
+++ b/tests/stubs/wordpress-stubs.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Structural stubs for symbols that the rule reflects on.
+ *
+ * Every other symbol used in the test data is resolved by name from symbols.json
+ * or the hooks package. Only symbols whose parents or parameter names get inspected need
+ * to be declared here.
+ */
+
+class WP_Date_Query {
+	public function sanitize_relation( $relation ) {}
+}
+
+class WP_Theme_JSON {
+	public function sanitize( $input = array(), $valid_block_names = array(), $valid_element_names = array(), $valid_variations = array() ) {}
+}
+
+function load_textdomain( $domain, $mofile, $locale = null ) {}

--- a/tests/tests.neon
+++ b/tests/tests.neon
@@ -1,14 +1,11 @@
 parameters:
-	scanDirectories:
-		- ../vendor/wordpress/wordpress
+	# Loaded as a bootstrap file because PHPStan's test case replaces the source locator
+	# that scanFiles and scanDirectories feed into. PHPStan 1.x loads its own config after
+	# this one, so overriding that service back only works on PHPStan 2.x.
+	bootstrapFiles:
+		- stubs/wordpress-stubs.php
 
 services:
-	# PHPStan's TestCase.neon swaps in a source locator that ignores scanDirectories,
-	# so restore the real one in order to reflect the WordPress source.
-	betterReflectionSourceLocator:
-		factory: @PHPStan\Reflection\BetterReflection\BetterReflectionSourceLocatorFactory::create
-		autowired: false
-
 	-
 		class: WPCompat\PHPStan\Rules\MethodExistsVisitor
 		tags:


### PR DESCRIPTION
The tests need almost nothing from WordPress core, just a couple of stubs for the branches where PHPStan reaches into the class hierarchy or reads parameter names.