### PR TITLE
Update the parameter change detection and add tests.

### DIFF
--- a/src/Generator/SymbolExtractor.php
+++ b/src/Generator/SymbolExtractor.php
@@ -9,6 +9,7 @@ use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
+use WPCompat\PHPStan\ParameterAdditionMatcher;
 
 /**
  * Extracts the symbol version data that gets written to symbols.json.
@@ -295,15 +296,12 @@ final class SymbolExtractor {
 			}
 
 			foreach ( $param_names as $pname ) {
-				$escaped_pname = preg_quote( $pname, '/' );
-				if (
-					preg_match( '/(?:Added|Introduced|Formalized|added)\s+.*(?:\$' . $escaped_pname . '|`\$?' . $escaped_pname . '`|\b' . $escaped_pname . '\b).*(?:parameter|argument)/i', $description ) === 1 ||
-					preg_match( '/(?:\$' . $escaped_pname . '|`\$?' . $escaped_pname . '`|\b' . $escaped_pname . '\b).*(?:parameter|argument).*(?:added|introduced)/i', $description ) === 1 ||
-					preg_match( '/(?:The\s+)?(?:\$' . $escaped_pname . '|`\$?' . $escaped_pname . '`).*(?:parameter|argument)?\s+was\s+added/i', $description ) === 1
-				) {
-					if ( ! isset( $parameters[ $pname ] ) || version_compare( $version, $parameters[ $pname ]['since'], '<' ) ) {
-						$parameters[ $pname ] = [ 'since' => $version ];
-					}
+				if ( ! ParameterAdditionMatcher::matches( $description, $pname ) ) {
+					continue;
+				}
+
+				if ( ! isset( $parameters[ $pname ] ) || version_compare( $version, $parameters[ $pname ]['since'], '<' ) ) {
+					$parameters[ $pname ] = [ 'since' => $version ];
 				}
 			}
 		}

--- a/src/ParameterAdditionMatcher.php
+++ b/src/ParameterAdditionMatcher.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace WPCompat\PHPStan;
+
+/**
+ * Determines whether the description of an `@since` tag states that a given parameter was added.
+ */
+final class ParameterAdditionMatcher {
+	public static function matches( string $description, string $param ): bool {
+		$escaped = preg_quote( $param, '/' );
+
+		// Matches the parameter name in its dollar prefixed, backticked, or bare word forms.
+		$name = '(?:\$' . $escaped . '|`\$?' . $escaped . '`|\b' . $escaped . ')(?![A-Za-z0-9_])';
+
+		// As above but without the bare word form, which is too loose for descriptions such as
+		// "A return value was added".
+		$variable = '(?:\$' . $escaped . '|`\$?' . $escaped . '`)(?![A-Za-z0-9_])';
+
+		foreach ( self::getSentences( $description ) as $sentence ) {
+			// The parameter is the destination of the change rather than the thing that was
+			// added, for example "Added `host_only` to the `$data` parameter".
+			if ( preg_match( '/\b(?:to|for|in|of|from)\s+(?:the\s+)?' . $name . '/i', $sentence ) === 1 ) {
+				continue;
+			}
+
+			if (
+				preg_match( '/(?:Added|Introduced|Formalized|added)\s+.*' . $name . '.*(?:parameter|argument)/i', $sentence ) === 1 ||
+				preg_match( '/' . $name . '.*(?:parameter|argument).*(?:added|introduced)/i', $sentence ) === 1 ||
+				preg_match( '/(?:The\s+)?' . $variable . '.*(?:parameter|argument)?\s+was\s+added/i', $sentence ) === 1
+			) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Splits a description into sentences so that a verb in one sentence can't be paired with a
+	 * parameter name in another.
+	 *
+	 * @return list<string>
+	 */
+	private static function getSentences( string $description ): array {
+		$sentences = preg_split( '/(?<=\.)\s+(?=[A-Z`$\'"])/', $description );
+
+		if ( $sentences === false ) {
+			return [ $description ];
+		}
+
+		return $sentences;
+	}
+}

--- a/src/Rules/SinceVersionRule.php
+++ b/src/Rules/SinceVersionRule.php
@@ -19,6 +19,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
+use WPCompat\PHPStan\ParameterAdditionMatcher;
 
 /**
  * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\CallLike>
@@ -174,18 +175,15 @@ final class SinceVersionRule implements Rule {
 					}
 
 					foreach ( $paramVars as $pos => $pvar ) {
-						$escapedVar = preg_quote( $pvar, '/' );
-						if (
-							preg_match( '/(?:Added|Introduced|Formalized|added)\s+.*(?:\$' . $escapedVar . '|`\$?' . $escapedVar . '`|\b' . $escapedVar . '\b).*(?:parameter|argument)/i', $desc ) === 1 ||
-							preg_match( '/(?:\$' . $escapedVar . '|`\$?' . $escapedVar . '`|\b' . $escapedVar . '\b).*(?:parameter|argument).*(?:added|introduced)/i', $desc ) === 1 ||
-							preg_match( '/(?:The\s+)?(?:\$' . $escapedVar . '|`\$?' . $escapedVar . '`).*(?:parameter|argument)?\s+was\s+added/i', $desc ) === 1
-						) {
-							if ( ! isset( $parameters[ $pos ] ) || version_compare( $ver, $parameters[ $pos ]['since'], '<' ) ) {
-								$parameters[ $pos ] = [
-									'name'  => $pvar,
-									'since' => $ver,
-								];
-							}
+						if ( ! ParameterAdditionMatcher::matches( $desc, $pvar ) ) {
+							continue;
+						}
+
+						if ( ! isset( $parameters[ $pos ] ) || version_compare( $ver, $parameters[ $pos ]['since'], '<' ) ) {
+							$parameters[ $pos ] = [
+								'name'  => $pvar,
+								'since' => $ver,
+							];
 						}
 					}
 				}

--- a/symbols.json
+++ b/symbols.json
@@ -4043,12 +4043,7 @@
             "since": "4.7.5"
         },
         "WP_Http_Cookie::__construct": {
-            "since": "2.8.0",
-            "parameters": {
-                "data": {
-                    "since": "5.2.0"
-                }
-            }
+            "since": "2.8.0"
         },
         "WP_Http_Cookie::getFullHeader": {
             "since": "2.8.0"
@@ -8436,12 +8431,7 @@
             "since": "1.5.0"
         },
         "WP_Rewrite::add_rule": {
-            "since": "2.1.0",
-            "parameters": {
-                "query": {
-                    "since": "4.4.0"
-                }
-            }
+            "since": "2.1.0"
         },
         "WP_Rewrite::flush_rules": {
             "since": "2.0.1"
@@ -9781,9 +9771,6 @@
         "WP_Theme::get_page_templates": {
             "since": "3.4.0",
             "parameters": {
-                "post": {
-                    "since": "4.7.0"
-                },
                 "post_type": {
                     "since": "4.7.0"
                 }
@@ -10571,12 +10558,7 @@
             "since": "3.3.0"
         },
         "WP_User::get_data_by": {
-            "since": "3.3.0",
-            "parameters": {
-                "field": {
-                    "since": "4.4.0"
-                }
-            }
+            "since": "3.3.0"
         },
         "WP_User::get_role_caps": {
             "since": "2.0.0"
@@ -12990,12 +12972,7 @@
             "since": "2.1.0"
         },
         "add_rewrite_rule": {
-            "since": "2.1.0",
-            "parameters": {
-                "query": {
-                    "since": "4.4.0"
-                }
-            }
+            "since": "2.1.0"
         },
         "add_rewrite_tag": {
             "since": "2.1.0"
@@ -15032,12 +15009,7 @@
             "since": "3.0.0"
         },
         "get_comment_link": {
-            "since": "1.5.0",
-            "parameters": {
-                "comment": {
-                    "since": "4.4.0"
-                }
-            }
+            "since": "1.5.0"
         },
         "get_comment_meta": {
             "since": "2.9.0"
@@ -15585,9 +15557,6 @@
         "get_page_templates": {
             "since": "1.5.0",
             "parameters": {
-                "post": {
-                    "since": "4.7.0"
-                },
                 "post_type": {
                     "since": "4.7.0"
                 }
@@ -16109,12 +16078,7 @@
             "since": "2.3.0"
         },
         "get_term_by": {
-            "since": "2.3.0",
-            "parameters": {
-                "field": {
-                    "since": "5.5.0"
-                }
-            }
+            "since": "2.3.0"
         },
         "get_term_children": {
             "since": "2.3.0"
@@ -16447,12 +16411,7 @@
             "since": "6.7.0"
         },
         "get_user_by": {
-            "since": "2.8.0",
-            "parameters": {
-                "field": {
-                    "since": "4.4.0"
-                }
-            }
+            "since": "2.8.0"
         },
         "get_user_by_email": {
             "deprecated": "3.3.0",
@@ -17941,9 +17900,6 @@
         "recurse_dirsize": {
             "since": "3.0.0",
             "parameters": {
-                "directory": {
-                    "since": "5.6.0"
-                },
                 "directory_cache": {
                     "since": "5.6.0"
                 },
@@ -21690,12 +21646,7 @@
             "since": "5.0.0"
         },
         "wp_enqueue_script": {
-            "since": "2.1.0",
-            "parameters": {
-                "args": {
-                    "since": "6.9.0"
-                }
-            }
+            "since": "2.1.0"
         },
         "wp_enqueue_script_module": {
             "since": "6.5.0",
@@ -21822,12 +21773,7 @@
             "since": "5.3.0"
         },
         "wp_generate_attachment_metadata": {
-            "since": "2.1.0",
-            "parameters": {
-                "file": {
-                    "since": "6.0.0"
-                }
-            }
+            "since": "2.1.0"
         },
         "wp_generate_auth_cookie": {
             "since": "2.5.0",
@@ -23781,12 +23727,7 @@
             "since": "6.2.0"
         },
         "wp_register_script": {
-            "since": "2.1.0",
-            "parameters": {
-                "args": {
-                    "since": "6.9.0"
-                }
-            }
+            "since": "2.1.0"
         },
         "wp_register_script_module": {
             "since": "6.5.0",

--- a/tests/Unit/SymbolExtractorTest.php
+++ b/tests/Unit/SymbolExtractorTest.php
@@ -57,6 +57,99 @@ class SymbolExtractorTest extends TestCase {
 					],
 				],
 			],
+			// The later @since tags describe args added to the `$args` array, not the addition
+			// of the `$args` parameter itself. Its introduction in 2.8.0 (as `$in_footer`) isn't
+			// documented, so no parameter data should be recorded.
+			'a function whose @since tags describe additions to an array parameter' => [
+				'wp-enqueue-script.php',
+				[
+					'wp_enqueue_script' => [
+						'since' => '2.1.0',
+					],
+				],
+			],
+			// "Array support was added to the `$query` parameter" describes a change to an
+			// existing parameter, not its addition.
+			'a function whose @since tag describes a change to a parameter' => [
+				'add-rewrite-rule.php',
+				[
+					'add_rewrite_rule' => [
+						'since' => '2.1.0',
+					],
+				],
+			],
+			// As above, for a method that inherits its @since from its class docblock.
+			'a method whose @since tag describes an addition to a parameter' => [
+				'wp-http-cookie.php',
+				[
+					'WP_Http_Cookie::__construct' => [
+						'since' => '2.8.0',
+					],
+				],
+			],
+			// "Added 'ID' as an alias of 'id' for the `$field` parameter" describes a new
+			// accepted value, not a new parameter.
+			'a function whose @since tag describes a new accepted value' => [
+				'get-user-by.php',
+				[
+					'get_user_by' => [
+						'since' => '2.8.0',
+					],
+				],
+			],
+			// `$post_type` was added in 4.7.0, `$post` was not.
+			'a function with a parameter whose name is a prefix of another' => [
+				'get-page-templates.php',
+				[
+					'get_page_templates' => [
+						'since' => '1.5.0',
+						'parameters' => [
+							'post_type' => [
+								'since' => '4.7.0',
+							],
+						],
+					],
+				],
+			],
+			// As above, where the prefixed parameter has genuine additions of its own.
+			'a function with several parameters added over time' => [
+				'recurse-dirsize.php',
+				[
+					'recurse_dirsize' => [
+						'since' => '3.0.0',
+						'parameters' => [
+							'directory_cache' => [
+								'since' => '5.6.0',
+							],
+							'exclude' => [
+								'since' => '4.3.0',
+							],
+							'max_execution_time' => [
+								'since' => '5.2.0',
+							],
+						],
+					],
+				],
+			],
+			// `$filesize` is a value in the returned array, not the `$file` parameter.
+			'a function whose @since tag describes a change to its return value' => [
+				'wp-generate-attachment-metadata.php',
+				[
+					'wp_generate_attachment_metadata' => [
+						'since' => '2.1.0',
+					],
+				],
+			],
+			// The first sentence mentions `$comment` and the second mentions an argument, but
+			// neither says that `$comment` was added.
+			'a function whose @since tag contains two sentences' => [
+				'get-comment-link.php',
+				[
+					'get_comment_link' => [
+						'since' => '1.5.0',
+					],
+				],
+			],
 		];
 	}
 }

--- a/tests/Unit/data/symbols/add-rewrite-rule.php
+++ b/tests/Unit/data/symbols/add-rewrite-rule.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * The docblock and signature of add_rewrite_rule(), copied verbatim from WordPress core:
+ * wp-includes/rewrite.php. The function body is omitted as it's not used.
+ */
+
+/**
+ * Adds a rewrite rule that transforms a URL structure to a set of query vars.
+ *
+ * Any value in the $after parameter that isn't 'bottom' will result in the rule
+ * being placed at the top of the rewrite rules.
+ *
+ * @since 2.1.0
+ * @since 4.4.0 Array support was added to the `$query` parameter.
+ *
+ * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
+ *
+ * @param string       $regex Regular expression to match request against.
+ * @param string|array $query The corresponding query vars for this rewrite rule.
+ * @param string       $after Optional. Priority of the new rule. Accepts 'top'
+ *                            or 'bottom'. Default 'bottom'.
+ */
+function add_rewrite_rule( $regex, $query, $after = 'bottom' ) {}

--- a/tests/Unit/data/symbols/get-comment-link.php
+++ b/tests/Unit/data/symbols/get-comment-link.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * The docblock and signature of get_comment_link(), copied verbatim from WordPress core:
+ * wp-includes/comment-template.php. The function body is omitted as it's not used.
+ */
+
+/**
+ * Retrieves the link to a given comment.
+ *
+ * @since 1.5.0
+ * @since 4.4.0 Added the ability for `$comment` to also accept a WP_Comment object. Added `$cpage` argument.
+ *
+ * @see get_page_of_comment()
+ *
+ * @global WP_Rewrite $wp_rewrite      WordPress rewrite component.
+ * @global bool       $in_comment_loop
+ *
+ * @param WP_Comment|int|null $comment Optional. Comment to retrieve. Default current comment.
+ * @param array               $args {
+ *     An array of optional arguments to override the defaults.
+ *
+ *     @type string     $type      Passed to get_page_of_comment().
+ *     @type int        $page      Current page of comments, for calculating comment pagination.
+ *     @type int        $per_page  Per-page value for comment pagination.
+ *     @type int        $max_depth Passed to get_page_of_comment().
+ *     @type int|string $cpage     Value to use for the comment's "comment-page" or "cpage" value.
+ *                                 If provided, this value overrides any value calculated from `$page`
+ *                                 and `$per_page`.
+ * }
+ * @return string The permalink to the given comment.
+ */
+function get_comment_link( $comment = null, $args = array() ) {}

--- a/tests/Unit/data/symbols/get-page-templates.php
+++ b/tests/Unit/data/symbols/get-page-templates.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * The docblock and signature of get_page_templates(), copied verbatim from WordPress core:
+ * wp-admin/includes/theme.php. The function body is omitted as it's not used.
+ */
+
+/**
+ * Gets the page templates available in this theme.
+ *
+ * @since 1.5.0
+ * @since 4.7.0 Added the `$post_type` parameter.
+ *
+ * @param WP_Post|null $post      Optional. The post being edited, provided for context.
+ * @param string       $post_type Optional. Post type to get the templates for. Default 'page'.
+ * @return string[] Array of template file names keyed by the template header name.
+ */
+function get_page_templates( $post = null, $post_type = 'page' ) {}

--- a/tests/Unit/data/symbols/get-user-by.php
+++ b/tests/Unit/data/symbols/get-user-by.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * The docblock and signature of get_user_by(), copied verbatim from WordPress core:
+ * wp-includes/pluggable.php. The function body is omitted as it's not used.
+ */
+
+/**
+ * Retrieves user info by a given field.
+ *
+ * @since 2.8.0
+ * @since 4.4.0 Added 'ID' as an alias of 'id' for the `$field` parameter.
+ *
+ * @global WP_User $current_user The current user object which holds the user data.
+ *
+ * @param string     $field The field to retrieve the user with. id | ID | slug | email | login.
+ * @param int|string $value A value for $field. A user ID, slug, email address, or login name.
+ * @return WP_User|false WP_User object on success, false on failure.
+ */
+function get_user_by( $field, $value ) {}

--- a/tests/Unit/data/symbols/recurse-dirsize.php
+++ b/tests/Unit/data/symbols/recurse-dirsize.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * The docblock and signature of recurse_dirsize(), copied verbatim from WordPress core:
+ * wp-includes/functions.php. The function body is omitted as it's not used.
+ */
+
+/**
+ * Gets the size of a directory recursively.
+ *
+ * Used by get_dirsize() to get a directory size when it contains other directories.
+ *
+ * @since MU (3.0.0)
+ * @since 4.3.0 The `$exclude` parameter was added.
+ * @since 5.2.0 The `$max_execution_time` parameter was added.
+ * @since 5.6.0 The `$directory_cache` parameter was added.
+ *
+ * @param string          $directory          Full path of a directory.
+ * @param string|string[] $exclude            Optional. Full path of a subdirectory to exclude from the total,
+ *                                            or array of paths. Expected without trailing slash(es).
+ *                                            Default null.
+ * @param int             $max_execution_time Optional. Maximum time to run before giving up. In seconds.
+ *                                            The timeout is global and is measured from the moment
+ *                                            WordPress started to load. Defaults to the value of
+ *                                            `max_execution_time` PHP setting.
+ * @param array           $directory_cache    Optional. Array of cached directory paths.
+ *                                            Defaults to the value of `dirsize_cache` transient.
+ * @return int|false|null Size in bytes if a valid directory. False if not. Null if timeout.
+ */
+function recurse_dirsize( $directory, $exclude = null, $max_execution_time = null, &$directory_cache = null ) {}

--- a/tests/Unit/data/symbols/wp-enqueue-script.php
+++ b/tests/Unit/data/symbols/wp-enqueue-script.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * The docblock and signature of wp_enqueue_script(), copied verbatim from WordPress core:
+ * wp-includes/functions.wp-scripts.php. The function body is omitted as it's not used.
+ */
+
+/**
+ * Enqueues a script.
+ *
+ * Registers the script if `$src` provided (does NOT overwrite), and enqueues it.
+ *
+ * @see WP_Dependencies::add()
+ * @see WP_Dependencies::add_data()
+ * @see WP_Dependencies::enqueue()
+ *
+ * @since 2.1.0
+ * @since 6.3.0 The $in_footer parameter of type boolean was overloaded to be an $args parameter of type array.
+ * @since 6.9.0 The $fetchpriority parameter of type string was added to the $args parameter of type array.
+ * @since 7.0.0 The $module_dependencies parameter of type string[] was added to the $args parameter of type array.
+ *
+ * @param string           $handle Name of the script. Should be unique.
+ * @param string           $src    Full URL of the script, or path of the script relative to the WordPress root directory.
+ *                                 Default empty.
+ * @param string[]         $deps   Optional. An array of registered script handles this script depends on. Default empty array.
+ * @param string|bool|null $ver    Optional. String specifying script version number, if it has one, which is added to the URL
+ *                                 as a query string for cache busting purposes. If version is set to false, a version
+ *                                 number is automatically added equal to current installed WordPress version.
+ *                                 If set to null, no version is added.
+ * @param array|bool $args {
+ *     Optional. An array of extra args for the script. Default empty array.
+ *     Otherwise, it may be a boolean in which case it determines whether the script is printed in the footer. Default false.
+ *
+ *     @type string $strategy            Optional. If provided, may be either 'defer' or 'async'.
+ *     @type bool   $in_footer           Optional. Whether to print the script in the footer. Default 'false'.
+ *     @type string $fetchpriority       Optional. The fetch priority for the script. Default 'auto'.
+ *     @type array  $module_dependencies Optional. IDs for module dependencies loaded via dynamic import. Default empty array.
+ *                                       For the full data format, see the `$deps` param of {@see wp_register_script_module()}.
+ *                                       When provided, the script must either be printed in the footer (with
+ *                                       `in_footer` set to true) or use a deferred loading `strategy` (`defer`),
+ *                                       so that the script modules import map is printed before the script
+ *                                       is evaluated. Otherwise dynamic imports may fail to resolve.
+ * }
+ *
+ * @phpstan-param non-empty-string $handle
+ * @phpstan-param string $src
+ * @phpstan-param non-empty-string[] $deps
+ * @phpstan-param array{
+ *     in_footer?: bool,
+ *     strategy?: 'async'|'defer',
+ *     fetchpriority?: 'low'|'auto'|'high',
+ *     module_dependencies?: array<non-empty-string|array{ id: non-empty-string, ... }>,
+ * }|bool $args
+ */
+function wp_enqueue_script( $handle, $src = '', $deps = array(), $ver = false, $args = array() ) {}

--- a/tests/Unit/data/symbols/wp-generate-attachment-metadata.php
+++ b/tests/Unit/data/symbols/wp-generate-attachment-metadata.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * The docblock and signature of wp_generate_attachment_metadata(), copied verbatim from WordPress core:
+ * wp-admin/includes/image.php. The function body is omitted as it's not used.
+ */
+
+/**
+ * Generates attachment meta data and create image sub-sizes for images.
+ *
+ * @since 2.1.0
+ * @since 6.0.0 The `$filesize` value was added to the returned array.
+ * @since 6.7.0 The 'image/heic' mime type is supported.
+ *
+ * @param int    $attachment_id Attachment ID to process.
+ * @param string $file          Filepath of the attached image.
+ * @return array Metadata for attachment.
+ */
+function wp_generate_attachment_metadata( $attachment_id, $file ) {}

--- a/tests/Unit/data/symbols/wp-http-cookie.php
+++ b/tests/Unit/data/symbols/wp-http-cookie.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * The docblock and signature of WP_Http_Cookie::__construct(), copied verbatim from
+ * WordPress core: wp-includes/class-wp-http-cookie.php. The method body and the rest of
+ * the class are omitted as they're not used.
+ */
+
+/**
+ * Core class used to encapsulate a single cookie object for internal use.
+ *
+ * Returned cookies are represented using this class, and when cookies are set, if they are not
+ * already a WP_Http_Cookie() object, then they are turned into one.
+ *
+ * @todo The WordPress convention is to use underscores instead of camelCase for function and method
+ * names. Need to switch to use underscores instead for the methods.
+ *
+ * @since 2.8.0
+ */
+#[AllowDynamicProperties]
+class WP_Http_Cookie {
+
+	/**
+	 * Sets up this cookie object.
+	 *
+	 * The parameter $data should be either an associative array containing the indices names below
+	 * or a header string detailing it.
+	 *
+	 * @since 2.8.0
+	 * @since 5.2.0 Added `host_only` to the `$data` parameter.
+	 *
+	 * @param string|array $data {
+	 *     Raw cookie data as header string or data array.
+	 *
+	 *     @type string          $name      Cookie name.
+	 *     @type mixed           $value     Value. Should NOT already be urlencoded.
+	 *     @type string|int|null $expires   Optional. Unix timestamp or formatted date. Default null.
+	 *     @type string          $path      Optional. Path. Default '/'.
+	 *     @type string          $domain    Optional. Domain. Default host of parsed $requested_url.
+	 *     @type int|string      $port      Optional. Port or comma-separated list of ports. Default null.
+	 *     @type bool            $host_only Optional. host-only storage flag. Default true.
+	 * }
+	 * @param string       $requested_url The URL which the cookie was set on, used for default $domain
+	 *                                    and $port values.
+	 */
+	public function __construct( $data, $requested_url = '' ) {}
+}


### PR DESCRIPTION
Some of the `@since` entries for symbol parameters are incorrect, due to the regex matching things it shouldn't. This fixes it and adds test coverage.